### PR TITLE
Add pending_htlcs and failed_payments as special metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PREFIX = bitdonkey/lnd-exporter
-TAG = 0.1.3
+PREFIX = bitcoindevproject/lnd-exporter-htlcs
+TAG = 0.2.0
 
 BUILD_DIR = build_output
 

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ TAG = 0.2.0
 BUILD_DIR = build_output
 
 container:
-	docker build -t $(PREFIX):$(TAG) .
+	docker buildx build --platform linux/amd64,linux/arm64,linux/armhf -t $(PREFIX):$(TAG) .
 
 push: container
 	docker push $(PREFIX):$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-PREFIX = bitcoindevproject/lnd-exporter-htlcs
+PREFIX = bitcoindevproject/lnd-exporter
 TAG = 0.2.0
 
 BUILD_DIR = build_output


### PR DESCRIPTION
adding "macro" metrics that are optionally available:

```
failed_payments=FAILED_PAYMENTS
pending_htlcs=PENDING_HTLCS
```

these get the API responses from LND but also do some processing on the response to compute a grafana-friendly time series:

<img width="1431" height="572" alt="Screenshot 2025-10-02 at 9 17 05 AM" src="https://github.com/user-attachments/assets/355e9d97-3e1c-481b-a78a-7c485fe30e8b" />
